### PR TITLE
Make hook work with actual versions of dehydrated

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -118,4 +118,17 @@ function unchanged_cert {
     exit 0
 }
 
+function invalid_challenge() {
+    exit 0
+}
+
+function startup_hook() {
+    exit 0
+}
+
+function exit_hook() {
+    exit 0
+}
+
+
 HANDLER=$1; shift; $HANDLER $@


### PR DESCRIPTION
Hello,
as some functions are missing, this hook does not work with dehydrated.
By adding dummy functions, it works again.