### PR TITLE
Ignore calls to hooks that don't exist

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -118,17 +118,8 @@ function unchanged_cert {
     exit 0
 }
 
-function invalid_challenge() {
-    exit 0
-}
 
-function startup_hook() {
-    exit 0
-}
-
-function exit_hook() {
-    exit 0
-}
-
-
-HANDLER=$1; shift; $HANDLER $@
+HANDLER=$1; shift
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert)$ ]]; then
+  "$HANDLER" "$@"
+fi


### PR DESCRIPTION
Hi,
here's a change to my last pull request:
- only call function if it exists
- remove dummy functions

This is required, as dehydrated now calls a random hook
https://github.com/lukas2511/dehydrated/commit/9ebab3e026569e79971fd7be14c522b22025150d

Kind regards,
Christian