### PR TITLE
Do not try to delete dns entry if there are no remaining entries

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -79,7 +79,11 @@ function clean_challenge {
 
     # select all records starting with _acme-challenge
     local dns_entry_list="$(<<<"${response}" grep -oP '(<item xsi:type="ns2:Map">(?:(?!<item xsi:type="ns2:Map">).)*_acme-challenge(?:(?!<item xsi:type="ns2:Map">).)*)')"
-    readarray dns_entries <<<"${dns_entry_list}"
+    if [[ ! "${dns_entry_list}" =~ ^[[:space:]]*$ ]]; then
+        readarray dns_entries <<<"${dns_entry_list}"
+    else
+        dns_entries=()
+    fi
 
     # check if there are any _acme-challenge entries left to delete
     if [[ ${#dns_entries[@]} -ne 0 ]]; then


### PR DESCRIPTION
Hello,

trying to receive a certificate for two domains, e.g.
domains.txt: `sub1.example.com sub2.sub1.example.com`
i got an error (domains changed for privacy reasons):

> Processing sub1.example.com with alternative names: sub2.sub1.example.com
>  + Creating new directory /etc/dehydrated/certs/sub1.example.com ...
>  + Signing domains...
>  + Generating private key...
>  + Generating signing request...
>  + Requesting new certificate order from CA...
>  + Received 2 authorizations URLs from the CA
>  + Handling authorization for sub1.example.com
>  + Handling authorization for sub2.sub1.example.com
>  + 2 pending challenge(s)
>  + Deploying challenge tokens...
>  + Hook: Adding DNS entry for sub1.example.com...
>  + Hook: DNS entry added successfully, waiting for propagation...
>  + Hook: Adding DNS entry for sub2.sub1.example.com...
>  + Hook: DNS entry added successfully, waiting for propagation...
>  + Responding to challenge for sub1.example.com authorization...
>  + Challenge is valid!
>  + Responding to challenge for sub2.sub1.example.com authorization...
>  + Challenge is valid!
>  + Cleaning challenge tokens...
>  + Hook: Fetching DNS entry list for sub1.example.com...
>  + Hook: DNS entry list fetched successfully.
>  + Hook: Deleting 2 DNS entries...
>  + Hook: Successfully deleted DNS entry 1/2.
>  + Hook: Successfully deleted DNS entry 2/2.
>  + Hook: Fetching DNS entry list for sub2.sub1.example.com...
>  + Hook: DNS entry list fetched successfully.
>  + Hook: Deleting 1 DNS entries...
> Hook ERROR: Request failed, faultstring: missing_parameter

As you can see, the two dns entries, that were added at the beginning, were already deleted, when it tries do delete another dns entry.
I found out, that `grep` always produces a result, that is put in `dns_entries` by `readarray`. If there is no match, there is an entry in `dns_entries` only containing whitespaces.

This is fixed by this pull request.

Kind regards,
Christian