### PR TITLE
switch to auth_type session because sha1 is disabled

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -35,7 +35,7 @@ function deploy_challenge {
 
     # send request and handle errors
     _echo "Adding DNS entry for ${DOMAIN}..."
-    response="$("${SCRIPTDIR}"/kasapi.sh/kasapi.sh -f "add_dns_settings" -p "${params}" 2>&1)"
+    response="$("${SCRIPTDIR}"/kasapi.sh/kasapi.sh --session -f "add_dns_settings" -p "${params}" 2>&1)"
     exitval="${?}"
     if [[ "${exitval}" -eq 0 ]]; then
         if command -v dig >/dev/null; then

--- a/hook.sh
+++ b/hook.sh
@@ -68,7 +68,7 @@ function clean_challenge {
 
     # send get request
     _echo "Fetching DNS entry list for ${DOMAIN}..."
-    response="$("${SCRIPTDIR}"/kasapi.sh/kasapi.sh -f "get_dns_settings" -p "${get_params}" 2>&1)"
+    response="$("${SCRIPTDIR}"/kasapi.sh/kasapi.sh --session -f "get_dns_settings" -p "${get_params}" 2>&1)"
     exitval="${?}"
     if [[ "${exitval}" -eq 0 ]]; then
         _echo "DNS entry list fetched successfully."
@@ -98,7 +98,7 @@ function clean_challenge {
             local params="${delete_params/ID/$(<<<"${dns_entries[i]}" grep -oP '(?<=<key xsi:type="xsd:string">record_id</key><value xsi:type="xsd:string">)[^<]+')}"
 
             # send delete request
-            response="$("${SCRIPTDIR}"/kasapi.sh/kasapi.sh -f "delete_dns_settings" -p "${params}" 2>&1)"
+            response="$("${SCRIPTDIR}"/kasapi.sh/kasapi.sh --session -f "delete_dns_settings" -p "${params}" 2>&1)"
             exitval="${?}"
             if [[ "${exitval}" -eq 0 ]]; then
                 _echo "Successfully deleted DNS entry $(( i + 1 ))/${#dns_entries[@]}."


### PR DESCRIPTION
When using `AuthType=sha1` the KAS API is returning `kas_auth_type_disabled` for me. 

Either it's linked to my account or, what I assume is true, they disabled `sha1`.

This PR switches to `AuthType=session` which works for me.

**ADDITIONALLY** you also need to switch to sending the `plain` password in `kasapi.sh` by changing the SOAP `AUTHREQUEST` from `"KasAuthType":"sha1"` to `"KasAuthType":"plain"` in line 21 and line 78 that sets `KASPWHASH` to use `${kas_pass}` instead of `${kas_pass_hash}`.  (The PR in that repository would thus involve some cleanup)

